### PR TITLE
Change bits used to compute index so that it doesn't overlap with rank.

### DIFF
--- a/include/hyperloglog.hpp
+++ b/include/hyperloglog.hpp
@@ -96,7 +96,7 @@ public:
     void add(const char* str, uint32_t len) {
         uint32_t hash;
         MurmurHash3_x86_32(str, len, HLL_HASH_SEED, (void*) &hash);
-        uint32_t index = hash & ((1 <<  b_) - 1);
+        uint32_t index = hash >> (32 - b_);
         uint8_t rank = _GET_CLZ((hash << b_), 32 - b_);
         if (rank > M_[index]) {
             M_[index] = rank;


### PR DESCRIPTION
Using a value for b which is 15 or 16 exhibits poor approximation with random input.